### PR TITLE
refactor(worker): Refactor Worker configuration

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/tab/smartid"
-	"github.com/tab/smartid/internal/config"
 )
 
 func main() {
@@ -33,11 +32,9 @@ func main() {
 		smartid.NewIdentity(smartid.TypePNO, "EE", "30403039983"),
 	}
 
-	worker := smartid.NewWorker(client)
-	worker.WithConfig(config.WorkerConfig{
-		Concurrency: 50,
-		QueueSize:   100,
-	})
+	worker := smartid.NewWorker(client).
+		WithConcurrency(50).
+		WithQueueSize(100)
 
 	ctx := context.Background()
 

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/tab/smartid"
-	"github.com/tab/smartid/internal/config"
 )
 
 func Example_CreateSession() {
@@ -82,11 +81,9 @@ func Example_ProcessMultipleIdentitiesInBackground() {
 		smartid.NewIdentity(smartid.TypePNO, "EE", "30403039983"),
 	}
 
-	worker := smartid.NewWorker(client)
-	worker.WithConfig(config.WorkerConfig{
-		Concurrency: 50,
-		QueueSize:   100,
-	})
+	worker := smartid.NewWorker(client).
+		WithConcurrency(50).
+		WithQueueSize(100)
 
 	ctx := context.Background()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,9 +13,3 @@ type Config struct {
 	URL              string
 	Timeout          time.Duration
 }
-
-// WorkerConfig is a struct holds the worker pool configuration options
-type WorkerConfig struct {
-	Concurrency int
-	QueueSize   int
-}

--- a/worker_mock.go
+++ b/worker_mock.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	config "github.com/tab/smartid/internal/config"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -79,16 +78,30 @@ func (mr *MockWorkerMockRecorder) Stop() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockWorker)(nil).Stop))
 }
 
-// WithConfig mocks base method.
-func (m *MockWorker) WithConfig(cfg config.WorkerConfig) Worker {
+// WithConcurrency mocks base method.
+func (m *MockWorker) WithConcurrency(concurrency int) Worker {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithConfig", cfg)
+	ret := m.ctrl.Call(m, "WithConcurrency", concurrency)
 	ret0, _ := ret[0].(Worker)
 	return ret0
 }
 
-// WithConfig indicates an expected call of WithConfig.
-func (mr *MockWorkerMockRecorder) WithConfig(cfg any) *gomock.Call {
+// WithConcurrency indicates an expected call of WithConcurrency.
+func (mr *MockWorkerMockRecorder) WithConcurrency(concurrency any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithConfig", reflect.TypeOf((*MockWorker)(nil).WithConfig), cfg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithConcurrency", reflect.TypeOf((*MockWorker)(nil).WithConcurrency), concurrency)
+}
+
+// WithQueueSize mocks base method.
+func (m *MockWorker) WithQueueSize(size int) Worker {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithQueueSize", size)
+	ret0, _ := ret[0].(Worker)
+	return ret0
+}
+
+// WithQueueSize indicates an expected call of WithQueueSize.
+func (mr *MockWorkerMockRecorder) WithQueueSize(size any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithQueueSize", reflect.TypeOf((*MockWorker)(nil).WithQueueSize), size)
 }


### PR DESCRIPTION
Updated Worker to use chainable methods for setting concurrency and queue size instead of a single config struct