### PR TITLE
fix(workflow): Update checks workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,12 +16,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: golangci-lint
-        # NOTE: https://github.com/golangci/golangci-lint-action/releases/tag/v6.2.0
-        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae
+        # NOTE: https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.0
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
         with:
-          version: v1.60
+          version: v1.64.5
 
   static-check:
     name: Staticcheck
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: staticcheck
         # NOTE: https://github.com/dominikh/staticcheck-action/releases/tag/v1.3.1
         uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ '1.22', '1.23' ]
+        version: [ '1.22', '1.23', '1.24' ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -54,8 +54,8 @@ jobs:
       - name: Run tests
         run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
       - name: Upload coverage to Codecov
-        if: matrix.version == '1.23'
-        # NOTE: https://github.com/codecov/codecov-action/tree/v5.3.1
+        if: matrix.version == '1.24'
+        # NOTE: https://github.com/codecov/codecov-action/releases/v5.3.1
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,5 +40,3 @@ linters-settings:
         disabled: true
   stylecheck:
     checks: ["^ST.*"]
-    ignored-checks:
-      - ST1003


### PR DESCRIPTION
- Changed Go version from 1.23 to 1.24
- Added Go 1.24 to the test matrix versions
- Updated golangci-lint action to version 6.5.0