### PR TITLE
latvian id format

### DIFF
--- a/internal/utils/certificate.go
+++ b/internal/utils/certificate.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/x509"
 	"encoding/base64"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -10,7 +11,8 @@ import (
 )
 
 var (
-	identityRegex = regexp.MustCompile(`^(PAS|IDC|PNO)([A-Z]{2})-([A-Za-z0-9]+)$`)
+	identityRegex        = regexp.MustCompile(`^(PAS|IDC|PNO)([A-Z]{2})-([A-Za-z0-9]+)$`)
+	latvianIdentityRegex = regexp.MustCompile(`^(PAS|IDC|PNO)([A-Z]{2})-([A-Za-z0-9]+)-([A-Za-z0-9]+)$`)
 )
 
 type Person struct {
@@ -63,13 +65,23 @@ func parse(value string) (*Identity, error) {
 	}
 
 	matches := identityRegex.FindStringSubmatch(value)
-	if len(matches) != 4 {
+	latvian := latvianIdentityRegex.FindStringSubmatch(value)
+
+	if len(matches) != 4 && len(latvian) != 5 {
 		return nil, errors.ErrInvalidIdentityNumber
 	}
 
-	return &Identity{
-		Type:    matches[1],
-		Country: matches[2],
-		ID:      matches[3],
-	}, nil
+	if len(latvian) != 0 {
+		return &Identity{
+			Type:    latvian[1],
+			Country: latvian[2],
+			ID:      fmt.Sprintf("%s-%s", latvian[3], latvian[4]),
+		}, nil
+	} else {
+		return &Identity{
+			Type:    matches[1],
+			Country: matches[2],
+			ID:      matches[3],
+		}, nil
+	}
 }


### PR DESCRIPTION
We use this library for integrating smart id in our projects, but we discovered that latvian identity code format is not supported. Latvian code comes with a '-' symbol between numbers like this: 111111-11111. Here maybe is not the best, but fastest solution