### PR TITLE
fix(requests): Support custom Smart-ID status codes

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -13,6 +13,11 @@ var (
 	ErrSmartIdProviderError   = errors.New("Smart-ID provider error")
 	ErrSmartIdSessionNotFound = errors.New("Smart-ID session not found or expired")
 
+	ErrSmartIdNoSuitableAccount = errors.New("no suitable account of requested type found")
+	ErrSmartIdViewApp           = errors.New("check Smart-ID app or self-service portal now")
+	ErrSmartIdClientTooOld      = errors.New("the client is too old and not supported anymore")
+	ErrSmartIdMaintenance       = errors.New("system is under maintenance, retry again later")
+
 	ErrInvalidCertificate    = errors.New("invalid certificate")
 	ErrInvalidIdentityNumber = errors.New("invalid identity number")
 

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -62,6 +62,54 @@ func Test_CreateAuthenticationSession(t *testing.T) {
 			error:    true,
 		},
 		{
+			name: "Error: 471 No Suitable Account",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusNoSuitableAccount)
+				w.Write([]byte(`{"title": "No Suitable Account", "status": 471}`))
+			},
+			identity: "PNOEE-30303039914",
+			expected: &Response{},
+			err:      errors.ErrSmartIdNoSuitableAccount,
+			error:    true,
+		},
+		{
+			name: "Error: 472 View Smart-ID App",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusViewSmartIdApp)
+				w.Write([]byte(`{"title": "View Smart-ID App", "status": 472}`))
+			},
+			identity: "PNOEE-30303039914",
+			expected: &Response{},
+			err:      errors.ErrSmartIdViewApp,
+			error:    true,
+		},
+		{
+			name: "Error: 473 Client Too Old",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusClientTooOld)
+				w.Write([]byte(`{"title": "Client Too Old", "status": 473}`))
+			},
+			identity: "PNOEE-30303039914",
+			expected: &Response{},
+			err:      errors.ErrSmartIdClientTooOld,
+			error:    true,
+		},
+		{
+			name: "Error: 474 System Maintenance",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusSystemMaintenance)
+				w.Write([]byte(`{"title": "System Maintenance", "status": 474}`))
+			},
+			identity: "PNOEE-30303039914",
+			expected: &Response{},
+			err:      errors.ErrSmartIdMaintenance,
+			error:    true,
+		},
+		{
 			name: "Error: Bad Request",
 			before: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
@@ -225,6 +273,54 @@ func Test_FetchAuthenticationSession(t *testing.T) {
 			id:       id,
 			expected: &models.AuthenticationResponse{},
 			err:      errors.ErrSmartIdProviderError,
+			error:    true,
+		},
+		{
+			name: "Error 471: No Suitable Account",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusNoSuitableAccount)
+				w.Write([]byte(`{"title": "No Suitable Account", "status": 471}`))
+			},
+			id:       id,
+			expected: &models.AuthenticationResponse{},
+			err:      errors.ErrSmartIdNoSuitableAccount,
+			error:    true,
+		},
+		{
+			name: "Error 472: View Smart-ID App",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusViewSmartIdApp)
+				w.Write([]byte(`{"title": "View Smart-ID App", "status": 472}`))
+			},
+			id:       id,
+			expected: &models.AuthenticationResponse{},
+			err:      errors.ErrSmartIdViewApp,
+			error:    true,
+		},
+		{
+			name: "Error 473: Client Too Old",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusClientTooOld)
+				w.Write([]byte(`{"title": "Client Too Old", "status": 473}`))
+			},
+			id:       id,
+			expected: &models.AuthenticationResponse{},
+			err:      errors.ErrSmartIdClientTooOld,
+			error:    true,
+		},
+		{
+			name: "Error 474: System Maintenance",
+			before: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(StatusSystemMaintenance)
+				w.Write([]byte(`{"title": "System Maintenance", "status": 474}`))
+			},
+			id:       id,
+			expected: &models.AuthenticationResponse{},
+			err:      errors.ErrSmartIdMaintenance,
 			error:    true,
 		},
 		{


### PR DESCRIPTION
Added custom HTTP status codes and error messages:
- 471 No suitable account of requested type found, but user has some other accounts
- 472 Person should view Smart-ID app or Smart-ID self-service portal now
- 480 The client is too old and not supported any more
- 580 System is under maintenance, retry again later