### PR TITLE
fix(tls): Rename certificate pinner to certificate manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,14 @@ import (
   "time"
 
   "github.com/tab/smartid"
-  "github.com/tab/smartid/internal/certificates"
 )
 
 func main() {
-  pinner, err := certificates.NewCertificatePinner("./certs")
+  manager, err := smartid.NewCertificateManager("./certs")
   if err != nil {
-    fmt.Println("Failed to create certificate pinner:", err)
+    fmt.Println("Failed to create certificate manager:", err)
   }
-  tlsConfig := pinner.TLSConfig()
+  tlsConfig := manager.TLSConfig()
 
   client := smartid.NewClient().
     WithRelyingPartyName("DEMO").

--- a/client_test.go
+++ b/client_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tab/smartid/internal/certificates"
 	"github.com/tab/smartid/internal/config"
 	"github.com/tab/smartid/internal/errors"
 )
@@ -355,10 +354,10 @@ func Test_WithTimeout(t *testing.T) {
 }
 
 func TestClient_WithTLSConfig(t *testing.T) {
-	pinner, err := certificates.NewCertificatePinner("./certs")
+	manager, err := NewCertificateManager("./certs")
 	assert.NoError(t, err)
 
-	tlsConfig := pinner.TLSConfig()
+	tlsConfig := manager.TLSConfig()
 
 	type result struct {
 		config *config.Config

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -7,15 +7,14 @@ import (
 	"time"
 
 	"github.com/tab/smartid"
-	"github.com/tab/smartid/internal/certificates"
 )
 
 func main() {
-	pinner, err := certificates.NewCertificatePinner("./certs")
+	manager, err := smartid.NewCertificateManager("./certs")
 	if err != nil {
-		fmt.Println("Failed to create certificate pinner:", err)
+		fmt.Println("Failed to create certificate manager:", err)
 	}
-	tlsConfig := pinner.TLSConfig()
+	tlsConfig := manager.TLSConfig()
 
 	client := smartid.NewClient().
 		WithRelyingPartyName("DEMO").

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -119,11 +119,11 @@ func Example_ProcessMultipleIdentitiesInBackground() {
 }
 
 func Example_ProcessMultipleIdentitiesInBackground_WithTLS() {
-	pinner, err := certificates.NewCertificatePinner("./certs")
+	manager, err := smartid.NewCertificateManager("./certs")
 	if err != nil {
-		fmt.Println("Failed to create certificate pinner:", err)
+		fmt.Println("Failed to create certificate manager:", err)
 	}
-	tlsConfig := pinner.TLSConfig()
+	tlsConfig := manager.TLSConfig()
 
 	client := smartid.NewClient().
 		WithRelyingPartyName("DEMO").

--- a/tls.go
+++ b/tls.go
@@ -1,4 +1,4 @@
-package certificates
+package smartid
 
 import (
 	"crypto/sha256"
@@ -6,27 +6,28 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 
+	"github.com/tab/smartid/internal/certificates"
 	"github.com/tab/smartid/internal/errors"
 )
 
-type Pinner struct {
+type Manager struct {
 	certificates []*x509.Certificate
 }
 
-// NewCertificatePinner creates a new certificate pinner instance
-func NewCertificatePinner(certsDir string) (*Pinner, error) {
-	certs, err := LoadFromDir(certsDir)
+// NewCertificateManager creates a new certificate manager instance
+func NewCertificateManager(certsDir string) (*Manager, error) {
+	certs, err := certificates.LoadFromDir(certsDir)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Pinner{
+	return &Manager{
 		certificates: certs,
 	}, nil
 }
 
-// TLSConfig returns a new tls.Config instance with the certificate pinner
-func (p *Pinner) TLSConfig() *tls.Config {
+// TLSConfig returns a new tls.Config instance with the certificate pinning
+func (p *Manager) TLSConfig() *tls.Config {
 	return &tls.Config{
 		VerifyPeerCertificate: p.VerifyPeerCertificate,
 		MinVersion:            tls.VersionTLS12,
@@ -34,7 +35,7 @@ func (p *Pinner) TLSConfig() *tls.Config {
 }
 
 // VerifyPeerCertificate verifies the peer certificate against the pinned certificates
-func (p *Pinner) VerifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+func (p *Manager) VerifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 	for _, rawCert := range rawCerts {
 		cert, err := x509.ParseCertificate(rawCert)
 		if err != nil {

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,4 +1,4 @@
-package certificates
+package smartid
 
 import (
 	"crypto/x509"
@@ -6,10 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/tab/smartid/internal/certificates"
 	"github.com/tab/smartid/internal/errors"
 )
 
-func Test_NewCertificatePinner(t *testing.T) {
+func Test_NewCertificateManager(t *testing.T) {
 	tests := []struct {
 		name string
 		dir  string
@@ -17,19 +18,19 @@ func Test_NewCertificatePinner(t *testing.T) {
 	}{
 		{
 			name: "Success",
-			dir:  "testdata/valid",
+			dir:  "internal/certificates/testdata/valid",
 			err:  nil,
 		},
 		{
 			name: "Error: Failed to read certificate file",
-			dir:  "testdata/missing",
+			dir:  "internal/certificates/testdata/missing",
 			err:  errors.ErrFailedToReadCertificateFile,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewCertificatePinner(tt.dir)
+			_, err := NewCertificateManager(tt.dir)
 
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
@@ -40,8 +41,8 @@ func Test_NewCertificatePinner(t *testing.T) {
 	}
 }
 
-func Test_Pinner_VerifyPeerCertificate(t *testing.T) {
-	certPEM, err := LoadFromFile("testdata/valid/cert.pem")
+func Test_Manager_VerifyPeerCertificate(t *testing.T) {
+	certPEM, err := certificates.LoadFromFile("internal/certificates/testdata/valid/cert.pem")
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -72,7 +73,7 @@ func Test_Pinner_VerifyPeerCertificate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Pinner{
+			p := &Manager{
 				certificates: tt.certs,
 			}
 
@@ -86,8 +87,8 @@ func Test_Pinner_VerifyPeerCertificate(t *testing.T) {
 	}
 }
 
-func Test_Pinner_TLSConfig(t *testing.T) {
-	p := &Pinner{}
+func Test_TLSConfig(t *testing.T) {
+	p := &Manager{}
 	config := p.TLSConfig()
 
 	assert.NotNil(t, config)


### PR DESCRIPTION
The certificate pinner functionality has been encapsulated in a new certificate manager