### PR TITLE
fix(requests): Add timeoutMs for FetchAuthenticationSession

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ const (
 	InteractionType  = requests.InteractionTypeDisplayTextAndPIN
 	DisplayText60    = "Enter PIN1"
 	DisplayText200   = "Confirm the authentication request and enter PIN1"
-	Timeout          = 60 * time.Second
+	Timeout          = requests.Timeout
 	URL              = "https://sid.demo.sk.ee/smart-id-rp/v2"
 )
 


### PR DESCRIPTION
`timeoutMs` - request long poll timeout value in milliseconds. The upper bound of timeout: 120000, minimum 1000. If not specified by the API client in the request, a value halfway between maximum and minimum is used.