### PR TITLE
chore(errors): Update ErrSmartIdAccessForbidden error message

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -11,7 +11,7 @@ var (
 	ErrUnsupportedHashType = errors.New("unsupported hash type, allowed hash types are SHA256, SHA384 or SHA512")
 
 	ErrSmartIdProviderError   = errors.New("Smart-ID provider error")
-	ErrSmartIdAccessForbidden = errors.New("Smart-ID access forbidden")
+	ErrSmartIdAccessForbidden = errors.New("Smart-ID access forbidden. User authorization by RelyingPartyName, RelyingPartyUUID and IP-address fails")
 	ErrSmartIdSessionNotFound = errors.New("Smart-ID session not found or expired")
 
 	ErrSmartIdNoSuitableAccount = errors.New("no suitable account of requested type found")


### PR DESCRIPTION
Clarified the reason for Smart-ID access being forbidden to include user authorization failure details