### PR TITLE
Accessable error definitions

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -2,6 +2,7 @@ package smartid
 
 import (
 	"context"
+	e "errors"
 	"fmt"
 
 	"github.com/tab/smartid/internal/errors"
@@ -34,11 +35,40 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("authentication failed: %s", e.Code)
 }
 
+// We must expose some internal error, otherwise
+func handleMappedError(err error) error {
+	if e.Is(err, errors.ErrAuthenticationIsRunning) {
+		return ErrAuthenticationIsRunning
+	} else if e.Is(err, errors.ErrSmartIdNoSuitableAccount) {
+		return ErrSmartIdNoSuitableAccount
+	} else if e.Is(err, errors.ErrSmartIdMaintenance) {
+		return ErrSmartIdMaintenance
+	}
+
+	return err
+}
+
+func handleMappedResponseError(err string) error {
+	switch err {
+	case USER_REFUSED,
+		USER_REFUSED_DISPLAYTEXTANDPIN,
+		USER_REFUSED_VC_CHOICE,
+		USER_REFUSED_CONFIRMATIONMESSAGE,
+		USER_REFUSED_CONFIRMATIONMESSAGE_WITH_VC_CHOICE,
+		USER_REFUSED_CERT_CHOICE:
+		return ErrUserRefused
+	case TIMEOUT:
+		return ErrTimeout
+	default:
+		return fmt.Errorf("%s", err)
+	}
+}
+
 // CreateSession creates authentication session with the Smart-ID provider
 func (c *client) CreateSession(ctx context.Context, nationalIdentityNumber string) (*Session, error) {
 	session, err := requests.CreateAuthenticationSession(ctx, c.config, nationalIdentityNumber)
 	if err != nil {
-		return nil, err
+		return nil, handleMappedError(err)
 	}
 
 	return (*Session)(session), nil
@@ -48,12 +78,12 @@ func (c *client) CreateSession(ctx context.Context, nationalIdentityNumber strin
 func (c *client) FetchSession(ctx context.Context, sessionId string) (*Person, error) {
 	response, err := requests.FetchAuthenticationSession(ctx, c.config, sessionId)
 	if err != nil {
-		return nil, err
+		return nil, handleMappedError(err)
 	}
 
 	switch response.State {
 	case Running:
-		return nil, errors.ErrAuthenticationIsRunning
+		return nil, ErrAuthenticationIsRunning
 	case Complete:
 		switch response.Result.EndResult {
 		case OK:
@@ -76,7 +106,7 @@ func (c *client) FetchSession(ctx context.Context, sessionId string) (*Person, e
 			USER_REFUSED_CERT_CHOICE,
 			WRONG_VC,
 			TIMEOUT:
-			return nil, &Error{Code: response.Result.EndResult}
+			return nil, handleMappedResponseError(response.Result.EndResult)
 		}
 	default:
 		return nil, errors.ErrUnsupportedState

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,11 @@
+package smartid
+
+import "errors"
+
+var (
+	ErrAuthenticationIsRunning  = errors.New("authentication is still running")
+	ErrSmartIdNoSuitableAccount = errors.New("no suitable account of requested type found")
+	ErrSmartIdMaintenance       = errors.New("system is under maintenance, retry again later")
+	ErrUserRefused              = errors.New("user refused")
+	ErrTimeout                  = errors.New("user didn't respond in time")
+)

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -101,7 +101,7 @@ func CreateAuthenticationSession(
 		}, nil
 	case http.StatusForbidden:
 		return nil, errors.ErrSmartIdAccessForbidden
-	case StatusNoSuitableAccount:
+	case StatusNoSuitableAccount, http.StatusNotFound:
 		return nil, errors.ErrSmartIdNoSuitableAccount
 	case StatusViewSmartIdApp:
 		return nil, errors.ErrSmartIdViewApp


### PR DESCRIPTION
We need to be able to access some of the error message definitions that is stored in inner package. For example we must have the ability to tell if we are still waiting for user confirmation when we are doing pooling.  As it is now we  in our code can't compare error message with errors.Is() function to control code flow properly as we can't import definitions

Plus smartid endpoint returns error 404, when it can't find account associeted with passed persons identification code.  As such we must display error message for this also

Here are forked changes we made 