### PR TITLE
chore(ci): Update golangci-lint and codecov-action versions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -20,8 +20,8 @@ jobs:
         with:
           go-version: '1.24'
       - name: golangci-lint
-        # NOTE: https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.0
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
+        # NOTE: https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.2
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         with:
           version: v1.64.5
 
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ '1.22', '1.23', '1.24' ]
+        version: [ '1.23', '1.24' ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -62,7 +62,7 @@ jobs:
         run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
       - name: Upload coverage to Codecov
         if: matrix.version == '1.24'
-        # NOTE: https://github.com/codecov/codecov-action/releases/v5.3.1
-        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
+        # NOTE: https://github.com/codecov/codecov-action/releases/v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Run coverage
         run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
       - name: Upload coverage to Codecov
-        # NOTE: https://github.com/codecov/codecov-action/releases/v5.3.1
-        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
+        # NOTE: https://github.com/codecov/codecov-action/releases/v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Updated golangci-lint-action to v6.5.2
- Updated codecov/codecov-action to v5.4.3